### PR TITLE
Fixes the deprecated jQuery call ".click"

### DIFF
--- a/src/bcp.js
+++ b/src/bcp.js
@@ -141,7 +141,7 @@
             });
 
             // Open popover on element click.
-            $(this).click(function () {
+            $(this).on("click", function () {
                 $(this).popover('toggle');
             });
 


### PR DESCRIPTION
The click-method is deprecated in jQuery. I replaced it with .on("click", function...

```
$(this).click(function() {
--> 
$(this).on("click",function() {
```
Would be nice to see the PR in one of the future releases :)